### PR TITLE
Updates for Kubernetes changes and GCE support

### DIFF
--- a/pods/app-etcd.yaml
+++ b/pods/app-etcd.yaml
@@ -2,6 +2,8 @@ apiVersion: v1beta3
 kind: Pod
 metadata:
   name: app-etcd
+  labels:
+    name: app-etcd
 spec:
   containers:
     - name: app-etcd
@@ -13,9 +15,7 @@ spec:
         - -advertise-client-urls
         - http://{{.LOCAL_IP}}:2379
       ports:
-        -
+        - name: listen-client-port
           containerPort: 2379
-          hostPort: 2379
-        -
+        - name: peer-port
           containerPort: 2380
-          hostPort: 2380

--- a/replication-controllers/couchbase-server.yaml
+++ b/replication-controllers/couchbase-server.yaml
@@ -21,8 +21,8 @@ spec:
         - name: couchbase-server
           image: couchbase/server:enterprise-4.0.0-dp
           ports:
-            - containerPort: 8091
-              hostPort: 8091
+            - name: webadministrationport
+              containerPort: 8091
         - name: couchbase-sidekick
           image: tleyden5iwx/couchbase-cluster-go:latest
           command:
@@ -32,5 +32,5 @@ spec:
             - start-couchbase-sidekick
             - --discover-local-ip
             - --etcd-servers
-            - http://etcd.pod.ip:2379
-
+            - http://$APP_ETCD_SERVICE_SERVICE_HOST:$APP_ETCD_SERVICE_SERVICE_PORT_CLIENTPORT
+            # Can also use http://app-etcd-service.kubernetes.local

--- a/replication-controllers/sync-gateway.yaml
+++ b/replication-controllers/sync-gateway.yaml
@@ -22,10 +22,8 @@ spec:
           image: couchbase/sync-gateway
           command:
             - sync_gateway
-            - https://raw.githubusercontent.com/couchbase/kubernetes/master/config/sync-gateway.config
+            - { "log": ["*"], "databases": { "db": { "server": "http://$COUCHBASE_SERVER_SERVICE_HOST:8091", "bucket": "default", "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } } } } }
           ports:
             - containerPort: 4984
-              hostPort: 4984
             - containerPort: 4985
-              hostPort: 4985
 

--- a/scripts/k8s-gce-cleanup.sh
+++ b/scripts/k8s-gce-cleanup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud compute firewall-rules delete --quiet cbs-8091

--- a/scripts/k8s-gce-register.sh
+++ b/scripts/k8s-gce-register.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Adds couchbase to an existing cluster on GCE
+#
+# Assumes you have a running kubernetes cluster
+# created with `echo curl -sS https://get.k8s.io | bash`
+# or a local Kubernetes source folder where
+# kubernetes/cluster/kube-up.sh was run
+
+CBUSER=user
+CBPASSWORD=user
+
+SKYDNS_DOMAIN=default.svc.cluster.local
+
+
+# pods
+printf "\nCreating pods ...\n"
+kubernetes/cluster/kubectl.sh create -f pods/app-etcd.yaml
+
+printf "\nWaiting for cluster to initialise ...\n"
+sleep 20
+kubernetes/cluster/kubectl.sh create -f services/app-etcd.yaml
+
+# config file adjustments
+printf "\nAdjusting config files ..."
+PODIP="app-etcd-service.$SKYDNS_DOMAIN"
+sleep 5
+
+gcloud --quiet compute ssh kubernetes-master --command "curl --silent -L http://localhost:8080/api/v1beta3/proxy/namespaces/default/pods/app-etcd:2379/v2/keys/couchbase.com/userpass -X PUT -d value='$CBUSER:$CBPASSWORD'"
+
+NODE1=$(gcloud compute instances list --format json | ./nodes.js | awk 'NR==1{print $1}')
+NODE2=$(gcloud compute instances list --format json | ./nodes.js | awk 'NR==2{print $1}')
+
+# Best practice to create pods/RC's before services
+# replication-controllers
+printf "\nCreating replication-controllers ...\n"
+kubernetes/cluster/kubectl.sh create -f replication-controllers/couchbase-server.yaml
+
+# services
+printf "\nCreating services ...\n"
+kubernetes/cluster/kubectl.sh create -f services/couchbase-service.yaml
+
+# firewall and forwarding-rules
+printf "\nCreating firewall and forwarding-rules ...\n"
+gcloud compute firewall-rules create cbs-8091 --allow tcp:30891 --target-tags kubernetes-minion
+
+# Done.
+CBNODEIP=$(gcloud compute instances describe $NODE1 --format json | jsawk 'return this.networkInterfaces[0].accessConfigs[0].natIP')
+
+# Can goto any k8s minion and get there, or go through the master
+printf "\nDone\n\n. Go to http://$CBNODEIP:30891\n\n or \n http://<k8smaster>:8080/api/v1beta3/proxy/namespaces/default/services/couchbase-service:8091/".

--- a/services/app-etcd.yaml
+++ b/services/app-etcd.yaml
@@ -6,11 +6,9 @@ spec:
   ports:
     - port: 2379
       name: clientport
-      targetPort: 2379
-      protocol: TCP
+      targetPort: listen-client-port
     - port: 2380
       name: servertoserverport
-      targetPort: 2380
-      protocol: TCP
+      targetPort: peer-port
   selector:
     name: app-etcd

--- a/services/couchbase-service.yaml
+++ b/services/couchbase-service.yaml
@@ -4,34 +4,32 @@ metadata:
   name: couchbase-service
 spec:
   ports:  # see http://docs.couchbase.com/admin/admin/Install/install-networkPorts.html
-    - port: 8091 
+    - port: 8091
       name: webadministrationport
-      targetPort: 8091
-      protocol: TCP
-    - port: 8092 
+      targetPort: webadministrationport
+      # default range 30000-32767
+      nodePort: 30891
+    - port: 8092
       name: couchbaseapiport
       targetPort: 8092
-      protocol: TCP
+      nodePort: 30892
     - port: 11207
       name: internalexternalbucketssl
       targetPort: 11207
-      protocol: TCP
     - port: 11210
       name: internalexternalbucket
       targetPort: 11210
-      protocol: TCP
     - port: 11211
       name: clientinterfaceproxy
       targetPort: 11211
-      protocol: TCP
     - port: 18091
       name: internalresthttps
       targetPort: 18091
-      protocol: TCP
     - port: 18092
       name: internalcapihttps
       targetPort: 18092
-      protocol: TCP
+  # type can be changed to "LoadBalancer" to automatically create an externally loadbalanced endpoint on GCE/AWS
+  type: "NodePort"
   # just like the selector in the replication controller,
   # but this time it identifies the set of pods to load balance
   # traffic to.


### PR DESCRIPTION
Added register/cleanup scripts for GCE in addition to GKE
Updated scripts to use skydns names instead of IPs from gcloud command
Added instructions for externally exposed load balanced services
Updated yaml files to use environment variables passed from services
Cleaned up deprecated hostPorts
Changed targetPorts to use named containerPorts for easier updating of containerPorts