### PR TITLE
Load Balancer and Config file updates

### DIFF
--- a/config/sync-gateway.config
+++ b/config/sync-gateway.config
@@ -2,7 +2,7 @@
   "log": ["*"],
   "databases": {
     "db": {
-      "server": "http://$COUCHBASE_SERVER_SERVICE_HOST:8091",
+      "server": "http://$COUCHBASE_SERVICE_SERVICE_HOST:8091",
       "bucket": "default",
       "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } }
     }

--- a/replication-controllers/couchbase-server.yaml
+++ b/replication-controllers/couchbase-server.yaml
@@ -28,11 +28,5 @@ spec:
           command:
             - /bin/sh
             - -c
-            - update-wrapper
-            - --skip-etcd-check
-            - couchbase-cluster
-            - start-couchbase-sidekick
-            - --discover-local-ip
-            - --etcd-servers
-            - http://$APP_ETCD_SERVICE_SERVICE_HOST:$APP_ETCD_SERVICE_SERVICE_PORT_CLIENTPORT
+            - update-wrapper --skip-etcd-check couchbase-cluster start-couchbase-sidekick --discover-local-ip --etcd-servers http://$APP_ETCD_SERVICE_SERVICE_HOST:$APP_ETCD_SERVICE_SERVICE_PORT_CLIENTPORT
             # Can also use http://app-etcd-service.kubernetes.local

--- a/replication-controllers/sync-gateway.yaml
+++ b/replication-controllers/sync-gateway.yaml
@@ -23,9 +23,14 @@ spec:
           command:
             - /bin/sh
             - -c
-            - sync_gateway
-            - https://raw.githubusercontent.com/couchbase/kubernetes/master/config/sync-gateway.config
-          ports:
+            - wget -O /sync-gateway-data/sync-gateway.config https://raw.githubusercontent.com/couchbase/kubernetes/master/config/sync-gateway.config && sed -i "s/\$COUCHBASE_SERVICE_SERVICE_HOST/$COUCHBASE_SERVICE_SERVICE_HOST/" /sync-gateway-data/sync-gateway.config && sync_gateway /sync-gateway-data/sync-gateway.config
+            rts:
             - containerPort: 4984
             - containerPort: 4985
+          volumeMounts:
+            - mountPath: /sync-gateway-data
+              name: data
+      volumes:
+        - name: data
+          emptyDir: {}
 

--- a/scripts/k8s-gce-register.sh
+++ b/scripts/k8s-gce-register.sh
@@ -42,10 +42,10 @@ kubernetes/cluster/kubectl.sh create -f services/couchbase-service.yaml
 
 # firewall and forwarding-rules
 printf "\nCreating firewall and forwarding-rules ...\n"
-gcloud compute firewall-rules create cbs-8091 --allow tcp:30891 --target-tags kubernetes-minion
+gcloud compute firewall-rules create cbs-8091 --allow tcp:8091 --target-tags kubernetes-minion
 
 # Done.
 CBNODEIP=$(gcloud compute instances describe $NODE1 --format json | jsawk 'return this.networkInterfaces[0].accessConfigs[0].natIP')
 
 # Can goto any k8s minion and get there, or go through the master
-printf "\nDone\n\n. Go to http://$CBNODEIP:30891\n\n or \n http://<k8smaster>:8080/api/v1beta3/proxy/namespaces/default/services/couchbase-service:8091/".
+printf "\nDone\n\n. Go to http://$CBNODEIP:8091\n\n or \n http://<k8smaster>:8080/api/v1beta3/proxy/namespaces/default/services/couchbase-service:8091/".

--- a/services/couchbase-service.yaml
+++ b/services/couchbase-service.yaml
@@ -8,7 +8,7 @@ spec:
       name: webadministrationport
       targetPort: webadministrationport
       # default range 30000-32767
-      nodePort: 30891
+      # nodePort: 30891
     - port: 8092
       name: couchbaseapiport
       targetPort: 8092
@@ -29,7 +29,8 @@ spec:
       name: internalcapihttps
       targetPort: 18092
   # type can be changed to "LoadBalancer" to automatically create an externally loadbalanced endpoint on GCE/AWS
-  type: "NodePort"
+  # type can be changed to "NodePort" to automatically create an externally loadbalanced endpoint on GCE/AWS
+  type: "LoadBalancer"
   # just like the selector in the replication controller,
   # but this time it identifies the set of pods to load balance
   # traffic to.


### PR DESCRIPTION
Change couchbase service to expose a load balanced endpoint for GCE/GKE/AWS by default (nodeport for self hosted)
Force resolution of environment variables in remote sync-gateway config file
Update pod command syntax for environment variable parsing
Improves upon #11