### PR TITLE
Add dedicated admin pod and upgrade to v1

### DIFF
--- a/config/sync-gateway.config
+++ b/config/sync-gateway.config
@@ -2,7 +2,7 @@
   "log": ["*"],
   "databases": {
     "db": {
-      "server": "http://10.0.101.12:8091",
+      "server": "http://couchbase-service.default.svc.cluster.local:8091",
       "bucket": "default",
       "users": { "GUEST": { "disabled": false, "admin_channels": ["*"] } }
     }

--- a/pods/app-etcd.yaml
+++ b/pods/app-etcd.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: Pod
 metadata:
   name: app-etcd
@@ -15,7 +15,7 @@ spec:
         - -advertise-client-urls
         - http://{{.LOCAL_IP}}:2379
       ports:
-        - name: listen-client-port
+        - name: client
           containerPort: 2379
-        - name: peer-port
+        - name: peer
           containerPort: 2380

--- a/replication-controllers/couchbase-admin-server.yaml
+++ b/replication-controllers/couchbase-admin-server.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: couchbase-controller
+  name: couchbase-admin-controller
 spec:
   replicas: 1
   # selector identifies the set of Pods that this
   # replicaController is responsible for managing
   selector:
     name: couchbase-server
-    role: nodes
+    role: admin
   # podTemplate defines the 'cookie cutter' used for creating
   # new pods when necessary
   template:
@@ -17,7 +17,7 @@ spec:
         # Important: these labels need to match the selector above
         # The api server enforces this constraint.
         name: couchbase-server
-        role: nodes
+        role: admin
     spec:
       containers:
         - name: couchbase-server
@@ -31,4 +31,3 @@ spec:
             - /bin/sh
             - -c
             - update-wrapper --skip-etcd-check couchbase-cluster start-couchbase-sidekick --discover-local-ip --etcd-servers http://$APP_ETCD_SERVICE_SERVICE_HOST:$APP_ETCD_SERVICE_SERVICE_PORT_CLIENT
-            # Can also use http://app-etcd-service.kubernetes.local

--- a/replication-controllers/sync-gateway.yaml
+++ b/replication-controllers/sync-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: ReplicationController
 metadata:
   name: sync-gateway

--- a/scripts/k8s-gce-register.sh
+++ b/scripts/k8s-gce-register.sh
@@ -42,6 +42,7 @@ kubernetes/cluster/kubectl.sh create -f services/couchbase-admin-service.yaml
 # firewall and forwarding-rules
 printf "\nCreating firewall and forwarding-rules ...\n"
 gcloud compute firewall-rules create cbs-8091 --allow tcp:8091 --target-tags kubernetes-minion
+gcloud compute firewall-rules create cbs-4984 --allow tcp:4984 --target-tags kubernetes-minion
 
 # Done.
 CBADMINIP=$(kubernetes/cluster/kubectl.sh get -o json service couchbase-admin-service | jsawk 'return this.status.loadBalancer.ingress[0].ip')

--- a/scripts/k8s-gce-register.sh
+++ b/scripts/k8s-gce-register.sh
@@ -8,25 +8,22 @@
 # kubernetes/cluster/kube-up.sh was run
 
 CBUSER=user
-CBPASSWORD=user
+CBPASSWORD=passw0rd
 
 SKYDNS_DOMAIN=default.svc.cluster.local
-
 
 # pods
 printf "\nCreating pods ...\n"
 kubernetes/cluster/kubectl.sh create -f pods/app-etcd.yaml
 
 printf "\nWaiting for cluster to initialise ...\n"
-sleep 20
+# sleep 20
 kubernetes/cluster/kubectl.sh create -f services/app-etcd.yaml
 
 # config file adjustments
 printf "\nAdjusting config files ..."
-PODIP="app-etcd-service.$SKYDNS_DOMAIN"
-sleep 5
 
-gcloud --quiet compute ssh kubernetes-master --command "curl --silent -L http://localhost:8080/api/v1beta3/proxy/namespaces/default/pods/app-etcd:2379/v2/keys/couchbase.com/userpass -X PUT -d value='$CBUSER:$CBPASSWORD'"
+gcloud compute ssh kubernetes-master --command "curl --silent -L http://localhost:8080/api/v1/proxy/namespaces/default/pods/app-etcd:2379/v2/keys/couchbase.com/userpass -X PUT -d value='$CBUSER:$CBPASSWORD'"
 
 NODE1=$(gcloud compute instances list --format json | ./nodes.js | awk 'NR==1{print $1}')
 NODE2=$(gcloud compute instances list --format json | ./nodes.js | awk 'NR==2{print $1}')
@@ -35,17 +32,21 @@ NODE2=$(gcloud compute instances list --format json | ./nodes.js | awk 'NR==2{pr
 # replication-controllers
 printf "\nCreating replication-controllers ...\n"
 kubernetes/cluster/kubectl.sh create -f replication-controllers/couchbase-server.yaml
+kubernetes/cluster/kubectl.sh create -f replication-controllers/couchbase-admin-server.yaml
 
 # services
 printf "\nCreating services ...\n"
 kubernetes/cluster/kubectl.sh create -f services/couchbase-service.yaml
+kubernetes/cluster/kubectl.sh create -f services/couchbase-admin-service.yaml
 
 # firewall and forwarding-rules
 printf "\nCreating firewall and forwarding-rules ...\n"
 gcloud compute firewall-rules create cbs-8091 --allow tcp:8091 --target-tags kubernetes-minion
 
 # Done.
-CBNODEIP=$(gcloud compute instances describe $NODE1 --format json | jsawk 'return this.networkInterfaces[0].accessConfigs[0].natIP')
+CBADMINIP=$(kubernetes/cluster/kubectl.sh get -o json service couchbase-admin-service | jsawk 'return this.status.loadBalancer.ingress[0].ip')
+
+# CBADMINIP=kubernetes/cluster/kubectl.sh get -o template service couchbase-admin-service --template={{.status.loadBalancer.ingress}}
 
 # Can goto any k8s minion and get there, or go through the master
-printf "\nDone\n\n. Go to http://$CBNODEIP:8091\n\n or \n http://<k8smaster>:8080/api/v1beta3/proxy/namespaces/default/services/couchbase-service:8091/".
+printf "\nDone.\n\n Go to http://$CBADMINIP:8091\n or \n http://<k8smaster>:8080/api/v1/proxy/namespaces/default/services/couchbase-admin-service:8091/".

--- a/services/app-etcd.yaml
+++ b/services/app-etcd.yaml
@@ -1,14 +1,14 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: Service
 metadata:
   name: app-etcd-service
 spec:
   ports:
     - port: 2379
-      name: clientport
-      targetPort: listen-client-port
+      name: client
+      targetPort: client
     - port: 2380
-      name: servertoserverport
-      targetPort: peer-port
+      name: peer
+      targetPort: peer
   selector:
     name: app-etcd

--- a/services/couchbase-admin-service.yaml
+++ b/services/couchbase-admin-service.yaml
@@ -1,14 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: couchbase-service
+  name: couchbase-admin-service
 spec:
   ports:  # see http://docs.couchbase.com/admin/admin/Install/install-networkPorts.html
     - port: 8091
       name: admin
       targetPort: admin
+  type: "LoadBalancer"
   # just like the selector in the replication controller,
   # but this time it identifies the set of pods to load balance
   # traffic to.
   selector:
     name: couchbase-server
+    role: admin

--- a/services/couchbase-service.yaml
+++ b/services/couchbase-service.yaml
@@ -7,29 +7,6 @@ spec:
     - port: 8091
       name: webadministrationport
       targetPort: webadministrationport
-      # default range 30000-32767
-      # nodePort: 30891
-    - port: 8092
-      name: couchbaseapiport
-      targetPort: 8092
-      nodePort: 30892
-    - port: 11207
-      name: internalexternalbucketssl
-      targetPort: 11207
-    - port: 11210
-      name: internalexternalbucket
-      targetPort: 11210
-    - port: 11211
-      name: clientinterfaceproxy
-      targetPort: 11211
-    - port: 18091
-      name: internalresthttps
-      targetPort: 18091
-    - port: 18092
-      name: internalcapihttps
-      targetPort: 18092
-  # type can be changed to "LoadBalancer" to automatically create an externally loadbalanced endpoint on GCE/AWS
-  # type can be changed to "NodePort" to automatically create an externally loadbalanced endpoint on GCE/AWS
   type: "LoadBalancer"
   # just like the selector in the replication controller,
   # but this time it identifies the set of pods to load balance

--- a/services/sync-gateway.yaml
+++ b/services/sync-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1beta3
+apiVersion: v1
 kind: Service
 metadata:
   name: sync-gateway-service
@@ -7,10 +7,9 @@ spec:
     - port: 4984
       name: apiport
       targetPort: 4984
-      protocol: TCP
+  type: "LoadBalancer"
   # just like the selector in the replication controller,
   # but this time it identifies the set of pods to load balance
   # traffic to.
   selector:
     name: sync-gateway
-  createExternalLoadBalancer: true


### PR DESCRIPTION
Adds a dedicated admin pod for the web ui, and eliminates any load balancing cookie issues when logging in to the web ui (#17)
- Upgrades to v1 api
- Adds firewall rules to allow sync-gateway port through (possible fix for #20)
- Updates the documentation for easier use and enables firewall ports to scale with GKE instances
- Updates the GCE auto-deployment scripts
- Removes unused couchbase server ports from the service