### PR TITLE
Exposing the 8092 port for views on the admin and the couchbase service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ Make a note of the Node it's running on (eg, gke-couchbase-server-648006db-node-
 
 ## Add Couchbase Server Admin credentials in etcd
 
+
+First, you will need to ssh into the host node where the app-etcd pod is running (or any other node in the cluster):
+
+
 ( Alternatively on linux and mac you can use this one liner )
 
 ```
 kubectl describe pod app-etcd | grep Node | awk '{print $2}'| sed 's/\/.*//'
 ```
-
-First, you will need to ssh into the host node where the app-etcd pod is running (or any other node in the cluster):
 
 ```
 $ gcloud compute ssh gke-couchbase-server-648006db-node-qgu2

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Make a note of the Node it's running on (eg, gke-couchbase-server-648006db-node-
 
 ## Add Couchbase Server Admin credentials in etcd
 
+( Alternatively on linux and mac you can use this one liner )
+kubectl describe pod app-etcd | grep Node | awk '{print $2}'| sed 's/\/.*//'
+
 First, you will need to ssh into the host node where the app-etcd pod is running (or any other node in the cluster):
 
 ```
@@ -73,6 +76,10 @@ $ gcloud compute ssh gke-couchbase-server-648006db-node-qgu2
 Replace `gcloud compute ssh gke-couchbase-server-648006db-node-qgu2` with the host found in the previous step.
 
 Next, use curl to add a value for the `/couchbase.com/userpass` key in etcd.  Use the Pod IP found above.  
+
+( Alternatively on linux and mac you can use this one liner to get the IP )
+
+kubectl describe pod app-etcd | grep IP: | awk '{print $2}'
 
 ```
 root@k8s~$ curl -L http://10.248.1.5:2379/v2/keys/couchbase.com/userpass -X PUT -d value="user:passw0rd"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ Make a note of the Node it's running on (eg, gke-couchbase-server-648006db-node-
 ## Add Couchbase Server Admin credentials in etcd
 
 ( Alternatively on linux and mac you can use this one liner )
+
+```
 kubectl describe pod app-etcd | grep Node | awk '{print $2}'| sed 's/\/.*//'
+```
 
 First, you will need to ssh into the host node where the app-etcd pod is running (or any other node in the cluster):
 
@@ -79,7 +82,9 @@ Next, use curl to add a value for the `/couchbase.com/userpass` key in etcd.  Us
 
 ( Alternatively on linux and mac you can use this one liner to get the IP )
 
+```
 kubectl describe pod app-etcd | grep IP: | awk '{print $2}'
+```
 
 ```
 root@k8s~$ curl -L http://10.248.1.5:2379/v2/keys/couchbase.com/userpass -X PUT -d value="user:passw0rd"

--- a/replication-controllers/couchbase-admin-server.yaml
+++ b/replication-controllers/couchbase-admin-server.yaml
@@ -25,6 +25,8 @@ spec:
           ports:
             - name: admin
               containerPort: 8091
+            - name: views
+              containerPort: 8092
         - name: couchbase-sidekick
           image: tleyden5iwx/couchbase-cluster-go:latest
           command:

--- a/replication-controllers/couchbase-server.yaml
+++ b/replication-controllers/couchbase-server.yaml
@@ -25,6 +25,8 @@ spec:
           ports:
             - name: admin
               containerPort: 8091
+            - name: views
+              containerPort: 8092
         - name: couchbase-sidekick
           image: tleyden5iwx/couchbase-cluster-go:latest
           command:

--- a/services/couchbase-admin-service.yaml
+++ b/services/couchbase-admin-service.yaml
@@ -7,6 +7,9 @@ spec:
     - port: 8091
       name: admin
       targetPort: admin
+    - port: 8092
+      name: views
+      targetPort: views
   type: "LoadBalancer"
   # just like the selector in the replication controller,
   # but this time it identifies the set of pods to load balance

--- a/services/couchbase-service.yaml
+++ b/services/couchbase-service.yaml
@@ -7,6 +7,9 @@ spec:
     - port: 8091
       name: admin
       targetPort: admin
+    - port: 8092
+      name: views
+      targetPort: views
   # just like the selector in the replication controller,
   # but this time it identifies the set of pods to load balance
   # traffic to.


### PR DESCRIPTION
Current setup does not allow the admin to click on the Views query link. This limits the admin and the containers from accessing the views from inside and outside the cluster. Limitation on Node port mapping make this difficult to do after the cluster has been deployed.