### PR TITLE
Couchbase templates for OpenShift - default to RHCC for images

### DIFF
--- a/openshift/couchbase-server-ephemeral.yaml
+++ b/openshift/couchbase-server-ephemeral.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: couchbase-server-ephemeral
+  description: Couchbase Server Enterprise
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: couchbase
+  spec:
+    replicas: 1
+    # selector identifies the set of Pods that this
+    # replicaController is responsible for managing
+    selector:
+      name: couchbase-server
+      role: nodes
+    # podTemplate defines the 'cookie cutter' used for creating
+    # new pods when necessary
+    template:
+      metadata:
+        labels:
+          # Important: these labels need to match the selector above
+          # The api server enforces this constraint.
+          name: couchbase-server
+          role: nodes
+      spec:
+        containers:
+          - name: couchbase-server
+            image: ${IMAGE_REPO}/server:${IMAGE_TAG}
+            ports:
+              - name: admin
+                containerPort: 8091
+              - name: views
+                containerPort: 8092
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames: 
+        - couchbase-server
+        from:
+          kind: ImageStreamTag
+          name: couchbase-server:${IMAGE_TAG}
+      type: ImageChange
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: couchbase-server
+  spec:
+    dockerImageRepository: ${IMAGE_REPO}/server:${IMAGE_TAG}
+    tags:
+    - annotations: 
+      from:
+        kind: ImageStreamTag
+        name: latest
+      name: latest
+      generation: 1
+      importPolicy: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: couchbase
+  spec:
+    ports:  # see http://docs.couchbase.com/admin/admin/Install/install-networkPorts.html
+      - port: 8091
+        name: admin
+        targetPort: admin
+      - port: 8092
+        name: views
+        targetPort: views
+    # just like the selector in the replication controller,
+    # but this time it identifies the set of pods to load balance
+    # traffic to.
+    selector:
+      name: couchbase-server
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+    labels:
+      app: couchbase-server-ephemeral
+    name: couchbase
+    namespace: testdb
+  spec:
+    port:
+      targetPort: admin
+    to:
+      kind: Service
+      name: couchbase
+      weight: 100
+    wildcardPolicy: None
+parameters:
+- name: IMAGE_REPO
+  displayName: Image Repository URL
+  description: "Image Repository URL"
+  value: registry.connect.redhat.com/couchbase
+  required: true
+- name: IMAGE_TAG
+  displayName: Image Tag Name
+  description: "Image Tag Name"
+  value: latest
+  required: true

--- a/openshift/couchbase-server-persistent.yaml
+++ b/openshift/couchbase-server-persistent.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: couchbase-server-persistent
+  description: Couchbase Server Enterprise
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: couchbase
+  spec:
+    replicas: 1
+    # selector identifies the set of Pods that this
+    # replicaController is responsible for managing
+    selector:
+      name: couchbase-server
+      role: nodes
+    # podTemplate defines the 'cookie cutter' used for creating
+    # new pods when necessary
+    template:
+      metadata:
+        labels:
+          # Important: these labels need to match the selector above
+          # The api server enforces this constraint.
+          name: couchbase-server
+          role: nodes
+      spec:
+        containers:
+          - name: couchbase-server
+            image: ${IMAGE_REPO}/server:${IMAGE_TAG}
+            ports:
+              - name: admin
+                containerPort: 8091
+              - name: views
+                containerPort: 8092
+            volumeMounts:
+            - mountPath: "/opt/couchbase/var"
+              name: cbvar
+        volumes:
+         - name: cbvar
+           persistentVolumeClaim:
+             claimName: couchbase
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames: 
+        - couchbase-server
+        from:
+          kind: ImageStreamTag
+          name: couchbase-server:${IMAGE_TAG}
+      type: ImageChange
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: couchbase-server
+  spec:
+    dockerImageRepository: ${IMAGE_REPO}/server:${IMAGE_TAG}
+    tags:
+    - annotations: 
+      from:
+        kind: ImageStreamTag
+        name: latest
+      name: latest
+      generation: 1
+      importPolicy: {}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: couchbase
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: couchbase
+  spec:
+    ports:  # see http://docs.couchbase.com/admin/admin/Install/install-networkPorts.html
+      - port: 8091
+        name: admin
+        targetPort: admin
+      - port: 8092
+        name: views
+        targetPort: views
+    # just like the selector in the replication controller,
+    # but this time it identifies the set of pods to load balance
+    # traffic to.
+    selector:
+      name: couchbase-server
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+    labels:
+      app: couchbase-server-ephemeral
+    name: couchbase
+    namespace: testdb
+  spec:
+    port:
+      targetPort: admin
+    to:
+      kind: Service
+      name: couchbase
+      weight: 100
+    wildcardPolicy: None
+parameters:
+- name: IMAGE_REPO
+  displayName: Image Repository URL
+  description: "Image Repository URL"
+  value: registry.connect.redhat.com/couchbase
+  required: true
+- name: IMAGE_TAG
+  displayName: Image Tag Name
+  description: "Image Tag Name"
+  value: latest
+  required: true


### PR DESCRIPTION
New functionality to accompany the upcoming Technical Implementation Guide for Couchbase Server on OpenShift.